### PR TITLE
Security: bump openssl + rustls-webpki for advisories (Closes #1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,9 +895,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -927,9 +927,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Closes #1.

Bumps two transitive crates via lockfile-only `cargo update --precise`:

- `openssl` `0.10.x` → **`0.10.78`** — addresses 4 HIGH (CVE-2026-41678/41681/41676 + GHSA-hppc-g8h3-xhp3) and 1 LOW (CVE-2026-41677)
- `rustls-webpki` `0.103.x` → **`0.103.13`** — addresses RUSTSEC-2026-0098/0099 (LOW, name constraints) and RUSTSEC-2026-0104 (panic in CRL parsing)

`Cargo.toml` unchanged. `cargo build` and `cargo test` clean locally.