### PR TITLE
chore: local verification just targets + pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Local-CI gate: run the verification suite before allowing a push.
+# Activated via `just install-hooks` (sets core.hooksPath = .githooks).
+# Bypass in an emergency with: git push --no-verify
+set -euo pipefail
+echo "==> pre-push: running 'just check' (bypass with --no-verify)"
+exec just check

--- a/justfile
+++ b/justfile
@@ -1,0 +1,28 @@
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+default:
+    @just --list
+
+# --- Local verification ("local CI") ---
+# Run locally instead of GitHub Actions. `install-hooks` wires `check` into a
+# git pre-push hook so it runs automatically before every push.
+check: fmt-check lint build test
+fmt-check:
+    cargo fmt --check
+fmt:
+    cargo fmt
+lint:
+    cargo clippy --all-targets -- -D warnings
+build:
+    cargo build
+test:
+    cargo test
+test-integration:
+    cargo test -- --ignored
+premerge:
+    git fetch origin
+    git rebase origin/main
+    just check
+install-hooks:
+    git config core.hooksPath .githooks
+    @echo "pre-push hook active — bypass once with: git push --no-verify"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 #![deny(warnings)]
 
 use axum::{
-    extract::{ws::WebSocketUpgrade, State},
+    Router,
+    extract::{State, ws::WebSocketUpgrade},
     response::Response,
     routing::get,
-    Router,
 };
 use clap::{Parser, ValueEnum};
 use geocode_mcp::error::Result;
@@ -172,10 +172,11 @@ async fn handle_websocket_connection(socket: axum::extract::ws::WebSocket, serve
 
                 if let Some(resp) = response
                     && let Ok(resp_str) = serde_json::to_string(&resp)
-                        && let Err(e) = sender.send(Message::Text(resp_str.into())).await {
-                            eprintln!("Error sending WebSocket response: {}", e);
-                            break;
-                        }
+                    && let Err(e) = sender.send(Message::Text(resp_str.into())).await
+                {
+                    eprintln!("Error sending WebSocket response: {}", e);
+                    break;
+                }
             }
             Ok(Message::Close(_)) => {
                 break;
@@ -191,11 +192,12 @@ async fn handle_websocket_connection(socket: axum::extract::ws::WebSocket, serve
 
 async fn handle_jsonrpc_message(server: Arc<McpServer>, message: Value) -> Option<Value> {
     if let Some(jsonrpc_version) = message.get("jsonrpc").and_then(|v| v.as_str())
-        && jsonrpc_version != "2.0" {
-            let id = message.get("id").cloned();
-            let error_msg = format!("Invalid JSON-RPC version: {}", jsonrpc_version);
-            return Some(jsonrpc_error_response(id, -32600, &error_msg, None));
-        }
+        && jsonrpc_version != "2.0"
+    {
+        let id = message.get("id").cloned();
+        let error_msg = format!("Invalid JSON-RPC version: {}", jsonrpc_version);
+        return Some(jsonrpc_error_response(id, -32600, &error_msg, None));
+    }
 
     let id = message.get("id").cloned();
     let method = message.get("method").and_then(|m| m.as_str());

--- a/src/operations/geocode.rs
+++ b/src/operations/geocode.rs
@@ -57,11 +57,9 @@ pub async fn geocode_location(
         .await?;
 
     if resp.features.is_empty() {
-        return Err(GeocodeError::LocationNotFound(format!(
-            "No locations found for: {}",
-            name
-        ))
-        .into());
+        return Err(
+            GeocodeError::LocationNotFound(format!("No locations found for: {}", name)).into(),
+        );
     }
 
     let locations: Vec<Value> = resp
@@ -89,11 +87,9 @@ pub async fn geocode_location(
         .collect();
 
     if locations.is_empty() {
-        return Err(GeocodeError::LocationNotFound(format!(
-            "No locations found for: {}",
-            name
-        ))
-        .into());
+        return Err(
+            GeocodeError::LocationNotFound(format!("No locations found for: {}", name)).into(),
+        );
     }
 
     Ok(serde_json::json!(locations))

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -57,16 +57,13 @@ impl ToolRegistry {
         let name = arguments
             .get("name")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| McpError::InvalidToolParameters("Missing required parameter: name".to_string()))?;
+            .ok_or_else(|| {
+                McpError::InvalidToolParameters("Missing required parameter: name".to_string())
+            })?;
 
-        let count = arguments
-            .get("count")
-            .and_then(value_as_u64)
-            .unwrap_or(5) as u32;
+        let count = arguments.get("count").and_then(value_as_u64).unwrap_or(5) as u32;
 
-        let language = arguments
-            .get("language")
-            .and_then(|v| v.as_str());
+        let language = arguments.get("language").and_then(|v| v.as_str());
 
         let result = geocode::geocode_location(&self.client, name, count, language).await?;
 

--- a/tests/mcp_stdio_suite.rs
+++ b/tests/mcp_stdio_suite.rs
@@ -1,6 +1,6 @@
 #![deny(warnings)]
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, Command, Stdio};
 
@@ -118,10 +118,10 @@ fn extract_value(tool_result: &Value) -> Value {
         .unwrap_or_else(|| panic!("expected result.content array, got: {tool_result}"));
 
     for entry in content {
-        if entry.get("type") == Some(&Value::String("json".to_string())) {
-            if let Some(v) = entry.get("value") {
-                return v.clone();
-            }
+        if entry.get("type") == Some(&Value::String("json".to_string()))
+            && let Some(v) = entry.get("value")
+        {
+            return v.clone();
         }
     }
 
@@ -330,10 +330,7 @@ fn test_geocode_nonexistent_location_network() {
     let mut client = McpStdioClient::start();
     client.initialize();
 
-    let result = client.tool_call(
-        "geocode",
-        json!({"name": "xyzzy_nonexistent_place_00000"}),
-    );
+    let result = client.tool_call("geocode", json!({"name": "xyzzy_nonexistent_place_00000"}));
     assert!(
         result.is_err(),
         "expected error for nonexistent location, but got success"


### PR DESCRIPTION
Mirrors the local-CI hygiene setup from desktop-assistant/adele-tui/adele-gtk.

- Adds a `justfile` with `check` (fmt-check + clippy `--all-targets -D warnings` + build + test), plus `fmt`, `fmt-check`, `lint`, `build`, `test`, `test-integration`, `premerge`, and `install-hooks`.
- Adds `.githooks/pre-push` that runs `just check` (activated via `just install-hooks`; bypass with `--no-verify`).
- Pins the toolchain to 1.96.0 via `rust-toolchain.toml` (rustfmt + clippy).
- Whole-crate `cargo fmt` applied (appropriate for a dedicated hygiene PR).
- One clippy fix: `clippy::collapsible_if` — collapsed a nested `if`/`if let` into a let-chain in `tests/mcp_stdio_suite.rs` (root-cause fix, no `#[allow]`).

`just check` passes locally: fmt-check + clippy clean, build OK, 10 tests pass.