### PR TITLE
Security & correctness fixes (2026-06-08 review)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,10 +62,216 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
@@ -87,14 +302,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -124,8 +339,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -137,9 +352,41 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -154,6 +401,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -223,7 +483,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -255,6 +515,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -293,6 +562,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +600,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,7 +628,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -334,6 +636,21 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -361,10 +678,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -403,6 +759,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,7 +785,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -456,10 +831,11 @@ dependencies = [
  "axum",
  "clap",
  "futures-util",
+ "httpmock",
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -491,6 +867,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,7 +889,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -522,6 +910,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,12 +938,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -549,8 +965,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -567,6 +983,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,8 +1044,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -594,8 +1061,8 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.9.0",
  "hyper-util",
  "rustls",
  "tokio",
@@ -609,18 +1076,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -764,6 +1231,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,7 +1257,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -796,7 +1272,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -815,7 +1291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -841,10 +1317,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -866,6 +1409,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru-slab"
@@ -903,6 +1449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +1471,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -950,10 +1508,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "potential_utf"
@@ -972,6 +1586,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -995,8 +1615,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
- "thiserror",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1018,7 +1638,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1033,7 +1653,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1092,20 +1712,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -1159,6 +1819,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1328,7 +2001,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1353,6 +2026,16 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
+dependencies = [
+ "regex",
+ "serde",
 ]
 
 [[package]]
@@ -1411,6 +2094,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +2116,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -1439,6 +2144,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +2166,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1478,7 +2206,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1503,12 +2231,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1519,7 +2278,16 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1559,7 +2327,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1572,7 +2340,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1635,8 +2403,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -1690,12 +2458,12 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1709,6 +2477,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -1739,6 +2513,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "version_check"
@@ -1822,7 +2602,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1865,6 +2645,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,6 +2668,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -2095,7 +2897,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2116,7 +2918,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2136,7 +2938,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2176,7 +2978,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ serde_json = "1.0"
 thiserror = "2.0.17"
 tokio = { version = "1.48.0", features = ["full"] }
 
+[dev-dependencies]
+httpmock = "0.7"
+
 [lints.rust]
 warnings = "deny"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,10 +253,21 @@ async fn handle_jsonrpc_message(server: Arc<McpServer>, message: Value) -> Optio
             let arguments = params.get("arguments").unwrap_or(&Value::Null);
 
             if let Some(name) = tool_name {
-                match server.handle_tool_call(name, arguments).await {
-                    Ok(result) => Ok(result),
-                    Err(e) => Err(e),
-                }
+                // Tool-execution errors are NOT JSON-RPC errors: per MCP spec they must be
+                // returned as a successful response with `isError: true` so the LLM can read
+                // the error message as tool output rather than as a transport failure.
+                let tool_result = match server.handle_tool_call(name, arguments).await {
+                    Ok(result) => result,
+                    Err(e) => serde_json::json!({
+                        "content": [{"type": "text", "text": e.to_string()}],
+                        "isError": true,
+                    }),
+                };
+                return Some(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": tool_result,
+                }));
             } else {
                 return Some(jsonrpc_error_response(
                     id,

--- a/src/operations/geocode.rs
+++ b/src/operations/geocode.rs
@@ -7,6 +7,8 @@ use crate::error::{GeocodeError, Result};
 use serde::Deserialize;
 use serde_json::Value;
 
+const PHOTON_API_URL: &str = "https://photon.komoot.io/api/";
+
 #[derive(Debug, Deserialize)]
 struct PhotonResponse {
     features: Vec<PhotonFeature>,
@@ -40,21 +42,44 @@ pub async fn geocode_location(
     count: u32,
     language: Option<&str>,
 ) -> Result<Value> {
+    geocode_location_with_base(client, PHOTON_API_URL, name, count, language).await
+}
+
+/// Geocode against a configurable base URL (used in tests to point at httpmock).
+pub async fn geocode_location_with_base(
+    client: &reqwest::Client,
+    base_url: &str,
+    name: &str,
+    count: u32,
+    language: Option<&str>,
+) -> Result<Value> {
     let count = count.clamp(1, 10);
     let language = language.unwrap_or("en");
 
-    let resp = client
-        .get("https://photon.komoot.io/api/")
+    let response = client
+        .get(base_url)
         .query(&[
             ("q", name),
             ("limit", &count.to_string()),
             ("lang", language),
         ])
-        .header("User-Agent", "geocode-mcp/0.1.0")
+        .header(
+            "User-Agent",
+            concat!("geocode-mcp/", env!("CARGO_PKG_VERSION")),
+        )
         .send()
-        .await?
-        .json::<PhotonResponse>()
         .await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(GeocodeError::ApiError(format!(
+            "Photon API returned HTTP {}",
+            status.as_u16()
+        ))
+        .into());
+    }
+
+    let resp = response.json::<PhotonResponse>().await?;
 
     if resp.features.is_empty() {
         return Err(

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -1,3 +1,4 @@
 #![deny(warnings)]
 
 pub mod geocode;
+pub mod reverse_geocode;

--- a/src/operations/reverse_geocode.rs
+++ b/src/operations/reverse_geocode.rs
@@ -1,0 +1,122 @@
+#![deny(warnings)]
+
+// Reverse geocoding: resolve latitude/longitude to a location name via Photon (Komoot)
+// https://photon.komoot.io — powered by OpenStreetMap data
+
+use crate::error::{GeocodeError, Result};
+use serde::Deserialize;
+use serde_json::Value;
+
+const PHOTON_REVERSE_URL: &str = "https://photon.komoot.io/reverse";
+
+#[derive(Debug, Deserialize)]
+struct PhotonResponse {
+    features: Vec<PhotonFeature>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PhotonFeature {
+    properties: PhotonProperties,
+    geometry: PhotonGeometry,
+}
+
+#[derive(Debug, Deserialize)]
+struct PhotonProperties {
+    name: Option<String>,
+    country: Option<String>,
+    countrycode: Option<String>,
+    state: Option<String>,
+    #[serde(rename = "type")]
+    place_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PhotonGeometry {
+    coordinates: Vec<f64>,
+}
+
+/// Reverse-geocode a latitude/longitude pair and return the nearest matching location.
+pub async fn reverse_geocode_location(
+    client: &reqwest::Client,
+    latitude: f64,
+    longitude: f64,
+    language: Option<&str>,
+) -> Result<Value> {
+    reverse_geocode_location_with_base(client, PHOTON_REVERSE_URL, latitude, longitude, language)
+        .await
+}
+
+/// Reverse-geocode against a configurable base URL (used in tests to point at httpmock).
+pub async fn reverse_geocode_location_with_base(
+    client: &reqwest::Client,
+    base_url: &str,
+    latitude: f64,
+    longitude: f64,
+    language: Option<&str>,
+) -> Result<Value> {
+    let language = language.unwrap_or("en");
+
+    let lat_str = latitude.to_string();
+    let lon_str = longitude.to_string();
+
+    let response = client
+        .get(base_url)
+        .query(&[
+            ("lat", lat_str.as_str()),
+            ("lon", lon_str.as_str()),
+            ("lang", language),
+        ])
+        .header(
+            "User-Agent",
+            concat!("geocode-mcp/", env!("CARGO_PKG_VERSION")),
+        )
+        .send()
+        .await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(GeocodeError::ApiError(format!(
+            "Photon reverse API returned HTTP {}",
+            status.as_u16()
+        ))
+        .into());
+    }
+
+    let resp = response.json::<PhotonResponse>().await?;
+
+    if resp.features.is_empty() {
+        return Err(GeocodeError::LocationNotFound(format!(
+            "No location found for coordinates: {}, {}",
+            latitude, longitude
+        ))
+        .into());
+    }
+
+    // Return the first (nearest) feature
+    let f = resp
+        .features
+        .into_iter()
+        .next()
+        .expect("non-empty checked above");
+
+    // Photon coordinates are [longitude, latitude] (GeoJSON order)
+    let coords = &f.geometry.coordinates;
+    if coords.len() < 2 {
+        return Err(GeocodeError::ApiError(
+            "Photon reverse API returned feature without coordinates".to_string(),
+        )
+        .into());
+    }
+
+    let result = serde_json::json!({
+        "name": f.properties.name,
+        "latitude": coords[1],
+        "longitude": coords[0],
+        "country": f.properties.country,
+        "country_code": f.properties.countrycode,
+        "region": f.properties.state,
+        "type": f.properties.place_type,
+    });
+
+    Ok(result)
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -36,8 +36,8 @@ impl McpServer {
             return Err(McpError::InvalidProtocolVersion(protocol_version.to_string()).into());
         }
 
-        let tools = self.tool_registry.list_tools();
-
+        // Per MCP spec the initialize result does NOT include a top-level "tools" list;
+        // tools are discovered via a separate tools/list request.
         let capabilities = serde_json::json!({
             "protocolVersion": protocol_version,
             "serverInfo": {
@@ -49,7 +49,6 @@ impl McpServer {
                     "listChanged": false,
                 },
             },
-            "tools": tools,
         });
 
         Ok(capabilities)

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -2,7 +2,9 @@
 
 use crate::error::{McpError, Result};
 use crate::operations::geocode;
+use crate::operations::reverse_geocode;
 use serde_json::Value;
+use std::time::Duration;
 
 /// Tool registry that manages all available tools
 pub struct ToolRegistry {
@@ -13,7 +15,11 @@ impl ToolRegistry {
     /// Create a new tool registry
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .connect_timeout(Duration::from_secs(5))
+                .build()
+                .expect("reqwest client"),
         }
     }
 
@@ -31,7 +37,10 @@ impl ToolRegistry {
                             "description": "Location name to search for. Supports city names, addresses, and points of interest. Examples: 'London', '1600 Pennsylvania Avenue', 'Eiffel Tower'."
                         },
                         "count": {
-                            "type": "number",
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 10,
+                            "default": 5,
                             "description": "Maximum number of results to return. Range: 1-10 (default: 5)."
                         },
                         "language": {
@@ -41,6 +50,28 @@ impl ToolRegistry {
                     },
                     "required": ["name"]
                 }
+            },
+            {
+                "name": "reverse_geocode",
+                "description": "Resolve geographic coordinates (latitude and longitude) to a location name and address using the Photon reverse geocoding API (powered by OpenStreetMap). Returns the nearest matching location with its name, country, region, and place type.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "latitude": {
+                            "type": "number",
+                            "description": "Latitude in decimal degrees (e.g. 51.5074 for London)."
+                        },
+                        "longitude": {
+                            "type": "number",
+                            "description": "Longitude in decimal degrees (e.g. -0.1278 for London)."
+                        },
+                        "language": {
+                            "type": "string",
+                            "description": "Language for result names (ISO 639-1 code). Default: 'en'. Example: 'de', 'fr', 'es'."
+                        }
+                    },
+                    "required": ["latitude", "longitude"]
+                }
             }
         ])
     }
@@ -49,6 +80,7 @@ impl ToolRegistry {
     pub async fn execute_tool(&self, tool_name: &str, arguments: &Value) -> Result<Value> {
         match tool_name {
             "geocode" => self.execute_geocode(arguments).await,
+            "reverse_geocode" => self.execute_reverse_geocode(arguments).await,
             _ => Err(McpError::ToolNotFound(tool_name.to_string()).into()),
         }
     }
@@ -61,13 +93,44 @@ impl ToolRegistry {
                 McpError::InvalidToolParameters("Missing required parameter: name".to_string())
             })?;
 
+        if name.trim().is_empty() {
+            return Err(McpError::InvalidToolParameters(
+                "Parameter 'name' must not be empty or whitespace-only".to_string(),
+            )
+            .into());
+        }
+
         let count = arguments.get("count").and_then(value_as_u64).unwrap_or(5) as u32;
 
         let language = arguments.get("language").and_then(|v| v.as_str());
 
         let result = geocode::geocode_location(&self.client, name, count, language).await?;
 
-        Ok(mcp_tool_result_json(result))
+        Ok(mcp_tool_result_text(result))
+    }
+
+    async fn execute_reverse_geocode(&self, arguments: &Value) -> Result<Value> {
+        let latitude = arguments
+            .get("latitude")
+            .and_then(|v| v.as_f64())
+            .ok_or_else(|| {
+                McpError::InvalidToolParameters("Missing required parameter: latitude".to_string())
+            })?;
+
+        let longitude = arguments
+            .get("longitude")
+            .and_then(|v| v.as_f64())
+            .ok_or_else(|| {
+                McpError::InvalidToolParameters("Missing required parameter: longitude".to_string())
+            })?;
+
+        let language = arguments.get("language").and_then(|v| v.as_str());
+
+        let result =
+            reverse_geocode::reverse_geocode_location(&self.client, latitude, longitude, language)
+                .await?;
+
+        Ok(mcp_tool_result_text(result))
     }
 }
 
@@ -82,13 +145,16 @@ fn value_as_u64(v: &Value) -> Option<u64> {
     v.as_u64().or_else(|| v.as_str()?.parse::<u64>().ok())
 }
 
-/// Wrap a JSON value in the MCP tool result content format.
-fn mcp_tool_result_json(value: Value) -> Value {
+/// Wrap a JSON value in the MCP tool result content format as a `text` content block.
+///
+/// MCP spec content types are `text`, `image`, and `resource`; `json` is non-standard.
+fn mcp_tool_result_text(value: Value) -> Value {
+    let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
     serde_json::json!({
         "content": [
             {
-                "type": "json",
-                "value": value,
+                "type": "text",
+                "text": text,
             }
         ]
     })

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -160,6 +160,17 @@ impl StdioTransportHandler {
             ))
         })?;
 
+        // Guard against unbounded allocation: a legitimate MCP message will never
+        // approach 16 MiB; anything larger is either a bug or an adversarial input.
+        const MAX_CONTENT_LENGTH: usize = 16 * 1024 * 1024; // 16 MiB
+        if content_length > MAX_CONTENT_LENGTH {
+            return Err(TransportError::InvalidMessage(format!(
+                "Content-Length {} exceeds maximum allowed size of {} bytes",
+                content_length, MAX_CONTENT_LENGTH,
+            ))
+            .into());
+        }
+
         loop {
             let mut header_line = String::new();
             let n = self

--- a/tests/mcp_stdio_suite.rs
+++ b/tests/mcp_stdio_suite.rs
@@ -94,11 +94,30 @@ impl McpStdioClient {
         self.notify("initialized", json!({}));
     }
 
+    /// Call a tool and return Ok(result) for success or Err(message) for both
+    /// JSON-RPC errors and MCP-level tool errors (`isError: true`).
     fn tool_call(&mut self, name: &str, arguments: Value) -> Result<Value, String> {
         let resp = self.call("tools/call", json!({"name":name,"arguments":arguments}))?;
-        resp.get("result")
+        let result = resp
+            .get("result")
             .cloned()
-            .ok_or_else(|| format!("missing result field: {resp}"))
+            .ok_or_else(|| format!("missing result field: {resp}"))?;
+
+        // Per MCP spec, tool errors come back as isError:true in the result body —
+        // surface them as Err so test assertions stay natural.
+        if result.get("isError") == Some(&Value::Bool(true)) {
+            let msg = result
+                .get("content")
+                .and_then(|c| c.as_array())
+                .and_then(|arr| arr.first())
+                .and_then(|entry| entry.get("text"))
+                .and_then(|t| t.as_str())
+                .unwrap_or("tool error")
+                .to_string();
+            return Err(msg);
+        }
+
+        Ok(result)
     }
 }
 
@@ -110,31 +129,36 @@ impl Drop for McpStdioClient {
     }
 }
 
-/// Extract the `value` field from the first `type: json` content entry.
-fn extract_value(tool_result: &Value) -> Value {
+/// Extract the JSON payload from the first `type: text` content entry.
+///
+/// The server now emits `{"type":"text","text":"<json string>"}` (MCP spec).
+fn extract_text_as_value(tool_result: &Value) -> Value {
     let content = tool_result
         .get("content")
         .and_then(|v| v.as_array())
         .unwrap_or_else(|| panic!("expected result.content array, got: {tool_result}"));
 
     for entry in content {
-        if entry.get("type") == Some(&Value::String("json".to_string()))
-            && let Some(v) = entry.get("value")
-        {
-            return v.clone();
+        if entry.get("type") == Some(&Value::String("text".to_string())) {
+            let text = entry
+                .get("text")
+                .and_then(|t| t.as_str())
+                .unwrap_or_else(|| panic!("text entry missing 'text' field: {entry}"));
+            return serde_json::from_str(text)
+                .unwrap_or_else(|e| panic!("text content is not valid JSON: {e}\n  text: {text}"));
         }
     }
 
-    panic!("no json content entry in: {tool_result}");
+    panic!("no text content entry in: {tool_result}");
 }
 
 fn network_tests_enabled() -> bool {
     std::env::var("RUN_NETWORK_TESTS").ok().as_deref() == Some("1")
 }
 
-fn expect_err_contains<T>(res: Result<T, String>, needle: &str) {
+fn expect_err_contains<T: std::fmt::Debug>(res: Result<T, String>, needle: &str) {
     match res {
-        Ok(_) => panic!("expected error containing '{needle}', but call succeeded"),
+        Ok(v) => panic!("expected error containing '{needle}', but call succeeded: {v:?}"),
         Err(e) => {
             let lower = e.to_lowercase();
             assert!(
@@ -147,7 +171,8 @@ fn expect_err_contains<T>(res: Result<T, String>, needle: &str) {
 
 // ── Protocol tests (no network) ───────────────────────────────────────────────
 
-/// The server must respond to `initialize` with serverInfo and capabilities.
+/// The server must respond to `initialize` with serverInfo and capabilities,
+/// and must NOT include a non-standard top-level `tools` key.
 #[test]
 fn test_initialize_response_shape() {
     let mut client = McpStdioClient::start();
@@ -172,6 +197,11 @@ fn test_initialize_response_shape() {
     assert!(
         result.get("capabilities").is_some(),
         "missing capabilities: {result}"
+    );
+    // Non-standard `tools` key must be absent from initialize response
+    assert!(
+        result.get("tools").is_none(),
+        "initialize result must not contain top-level 'tools' key: {result}"
     );
 }
 
@@ -207,7 +237,7 @@ fn test_tools_list_contains_expected_tools() {
             .collect()
     };
 
-    let expected = ["geocode"];
+    let expected = ["geocode", "reverse_geocode"];
 
     for expected_name in &expected {
         assert!(
@@ -230,9 +260,9 @@ fn test_tool_call_before_initialize_returns_error() {
     );
 }
 
-/// An unknown tool name must return a ToolNotFound error.
+/// An unknown tool name must return a tool error (isError:true), not a JSON-RPC error.
 #[test]
-fn test_unknown_tool_returns_error() {
+fn test_unknown_tool_returns_is_error() {
     let mut client = McpStdioClient::start();
     client.initialize();
     let result = client.tool_call("nonexistent_tool", json!({}));
@@ -277,6 +307,336 @@ fn test_geocode_missing_name() {
     expect_err_contains(result, "name");
 }
 
+/// `geocode` must reject an empty name.
+#[test]
+fn test_geocode_empty_name_rejected() {
+    let mut client = McpStdioClient::start();
+    client.initialize();
+    let result = client.tool_call("geocode", json!({"name": ""}));
+    expect_err_contains(result, "empty");
+}
+
+/// `geocode` must reject a whitespace-only name.
+#[test]
+fn test_geocode_whitespace_name_rejected() {
+    let mut client = McpStdioClient::start();
+    client.initialize();
+    let result = client.tool_call("geocode", json!({"name": "   "}));
+    expect_err_contains(result, "empty");
+}
+
+/// `reverse_geocode` must reject missing latitude.
+#[test]
+fn test_reverse_geocode_missing_latitude() {
+    let mut client = McpStdioClient::start();
+    client.initialize();
+    let result = client.tool_call("reverse_geocode", json!({"longitude": -0.1278}));
+    expect_err_contains(result, "latitude");
+}
+
+/// `reverse_geocode` must reject missing longitude.
+#[test]
+fn test_reverse_geocode_missing_longitude() {
+    let mut client = McpStdioClient::start();
+    client.initialize();
+    let result = client.tool_call("reverse_geocode", json!({"latitude": 51.5074}));
+    expect_err_contains(result, "longitude");
+}
+
+// ── httpmock-based unit tests (run unconditionally — no external network needed) ─
+
+#[cfg(test)]
+mod httpmock_tests {
+    use geocode_mcp::operations::geocode::geocode_location_with_base;
+    use geocode_mcp::operations::reverse_geocode::reverse_geocode_location_with_base;
+    use httpmock::prelude::*;
+    use std::time::Duration;
+
+    fn test_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .connect_timeout(Duration::from_secs(5))
+            .build()
+            .expect("reqwest client")
+    }
+
+    /// Zero-feature response must produce an isError-style LocationNotFound error.
+    #[tokio::test]
+    async fn test_geocode_empty_features_is_location_not_found() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/api/");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{"features":[]}"#);
+            })
+            .await;
+
+        let client = test_client();
+        let base = format!("http://{}/api/", server.address());
+        let result = geocode_location_with_base(&client, &base, "Atlantis", 5, None).await;
+
+        assert!(result.is_err(), "expected LocationNotFound error");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.to_lowercase().contains("not found"),
+            "expected 'not found' in error, got: {err}"
+        );
+    }
+
+    /// Malformed JSON from Photon (missing geometry.coordinates) must be handled gracefully.
+    #[tokio::test]
+    async fn test_geocode_missing_coordinates_filtered_out() {
+        let server = MockServer::start_async().await;
+        // Feature with coordinates array too short; should be filtered and trigger LocationNotFound
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/api/");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(
+                        r#"{
+                            "features": [
+                                {
+                                    "properties": {"name": "Broken", "country": "Nowhere"},
+                                    "geometry": {"coordinates": []}
+                                }
+                            ]
+                        }"#,
+                    );
+            })
+            .await;
+
+        let client = test_client();
+        let base = format!("http://{}/api/", server.address());
+        let result = geocode_location_with_base(&client, &base, "Broken", 5, None).await;
+
+        assert!(result.is_err(), "expected error for missing coordinates");
+    }
+
+    /// HTTP 429 from Photon must surface as an ApiError, not a panic or timeout.
+    #[tokio::test]
+    async fn test_geocode_http_429_propagates() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/api/");
+                then.status(429);
+            })
+            .await;
+
+        let client = test_client();
+        let base = format!("http://{}/api/", server.address());
+        let result = geocode_location_with_base(&client, &base, "London", 5, None).await;
+
+        assert!(result.is_err(), "expected error for HTTP 429");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("429"),
+            "expected 429 in error message, got: {err}"
+        );
+    }
+
+    /// HTTP 503 from Photon must surface as an ApiError.
+    #[tokio::test]
+    async fn test_geocode_http_503_propagates() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/api/");
+                then.status(503);
+            })
+            .await;
+
+        let client = test_client();
+        let base = format!("http://{}/api/", server.address());
+        let result = geocode_location_with_base(&client, &base, "London", 5, None).await;
+
+        assert!(result.is_err(), "expected error for HTTP 503");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("503"),
+            "expected 503 in error message, got: {err}"
+        );
+    }
+
+    /// count must be clamped: 0 → 1, 11 → 10.
+    #[tokio::test]
+    async fn test_geocode_count_clamping() {
+        let server = MockServer::start_async().await;
+
+        // Accept any limit value; return a single feature
+        let feature = r#"{
+            "features": [{
+                "properties": {"name": "London", "country": "United Kingdom", "countrycode": "GB", "state": "England", "type": "city"},
+                "geometry": {"coordinates": [-0.1278, 51.5074]}
+            }]
+        }"#;
+
+        server
+            .mock_async(|when, then| {
+                // count=0 should be clamped to 1
+                when.method(GET).path("/api/").query_param("limit", "1");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(feature);
+            })
+            .await;
+        server
+            .mock_async(|when, then| {
+                // count=11 should be clamped to 10
+                when.method(GET).path("/api/").query_param("limit", "10");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(feature);
+            })
+            .await;
+
+        let client = test_client();
+        let base = format!("http://{}/api/", server.address());
+
+        let r0 = geocode_location_with_base(&client, &base, "London", 0, None).await;
+        assert!(r0.is_ok(), "count=0 clamped to 1 should succeed: {r0:?}");
+
+        let r11 = geocode_location_with_base(&client, &base, "London", 11, None).await;
+        assert!(
+            r11.is_ok(),
+            "count=11 clamped to 10 should succeed: {r11:?}"
+        );
+    }
+
+    /// A valid Photon response must parse into expected fields.
+    #[tokio::test]
+    async fn test_geocode_valid_response_parsed() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/api/");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(
+                        r#"{
+                            "features": [{
+                                "properties": {
+                                    "name": "London",
+                                    "country": "United Kingdom",
+                                    "countrycode": "GB",
+                                    "state": "England",
+                                    "type": "city"
+                                },
+                                "geometry": {"coordinates": [-0.1278, 51.5074]}
+                            }]
+                        }"#,
+                    );
+            })
+            .await;
+
+        let client = test_client();
+        let base = format!("http://{}/api/", server.address());
+        let result = geocode_location_with_base(&client, &base, "London", 1, None)
+            .await
+            .expect("geocode should succeed");
+
+        let arr = result.as_array().expect("result should be array");
+        assert_eq!(arr.len(), 1);
+        let loc = &arr[0];
+        assert_eq!(loc["name"], "London");
+        assert_eq!(loc["country_code"], "GB");
+        // GeoJSON [lon, lat] → mapped correctly
+        assert!((loc["latitude"].as_f64().unwrap() - 51.5074).abs() < 0.001);
+        assert!((loc["longitude"].as_f64().unwrap() - (-0.1278)).abs() < 0.001);
+    }
+
+    /// reverse_geocode: HTTP 429 must propagate as an error.
+    #[tokio::test]
+    async fn test_reverse_geocode_http_429_propagates() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/reverse");
+                then.status(429);
+            })
+            .await;
+
+        let client = test_client();
+        let base = format!("http://{}/reverse", server.address());
+        let result =
+            reverse_geocode_location_with_base(&client, &base, 51.5074, -0.1278, None).await;
+
+        assert!(result.is_err(), "expected error for HTTP 429");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("429"),
+            "expected 429 in error message, got: {err}"
+        );
+    }
+
+    /// reverse_geocode: empty features must produce LocationNotFound.
+    #[tokio::test]
+    async fn test_reverse_geocode_empty_features_is_location_not_found() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/reverse");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{"features":[]}"#);
+            })
+            .await;
+
+        let client = test_client();
+        let base = format!("http://{}/reverse", server.address());
+        let result =
+            reverse_geocode_location_with_base(&client, &base, 51.5074, -0.1278, None).await;
+
+        assert!(result.is_err(), "expected LocationNotFound");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.to_lowercase().contains("not found"),
+            "expected 'not found', got: {err}"
+        );
+    }
+
+    /// reverse_geocode: valid response must parse correctly.
+    #[tokio::test]
+    async fn test_reverse_geocode_valid_response_parsed() {
+        let server = MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(GET).path("/reverse");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(
+                        r#"{
+                            "features": [{
+                                "properties": {
+                                    "name": "London",
+                                    "country": "United Kingdom",
+                                    "countrycode": "GB",
+                                    "state": "England",
+                                    "type": "city"
+                                },
+                                "geometry": {"coordinates": [-0.1278, 51.5074]}
+                            }]
+                        }"#,
+                    );
+            })
+            .await;
+
+        let client = test_client();
+        let base = format!("http://{}/reverse", server.address());
+        let result = reverse_geocode_location_with_base(&client, &base, 51.5074, -0.1278, None)
+            .await
+            .expect("reverse geocode should succeed");
+
+        assert_eq!(result["name"], "London");
+        assert_eq!(result["country_code"], "GB");
+        assert!((result["latitude"].as_f64().unwrap() - 51.5074).abs() < 0.001);
+        assert!((result["longitude"].as_f64().unwrap() - (-0.1278)).abs() < 0.001);
+    }
+}
+
 // ── Network integration tests (require RUN_NETWORK_TESTS=1) ──────────────────
 
 /// Geocode "London" and verify we get a plausible UK result.
@@ -294,7 +654,7 @@ fn test_geocode_london_network() {
         .tool_call("geocode", json!({"name": "London", "count": 3}))
         .expect("geocode London");
 
-    let locations = extract_value(&result);
+    let locations = extract_text_as_value(&result);
     let arr = locations.as_array().expect("expected array of locations");
     assert!(!arr.is_empty(), "expected at least one geocode result");
 
@@ -319,7 +679,7 @@ fn test_geocode_london_network() {
     );
 }
 
-/// Geocode an unknown location must return a LocationNotFound error.
+/// Geocode an unknown location must return an isError response (not JSON-RPC error).
 #[test]
 fn test_geocode_nonexistent_location_network() {
     if !network_tests_enabled() {
@@ -333,7 +693,7 @@ fn test_geocode_nonexistent_location_network() {
     let result = client.tool_call("geocode", json!({"name": "xyzzy_nonexistent_place_00000"}));
     assert!(
         result.is_err(),
-        "expected error for nonexistent location, but got success"
+        "expected isError for nonexistent location, but got success"
     );
 }
 
@@ -355,7 +715,7 @@ fn test_geocode_with_language_network() {
         )
         .expect("geocode Tokyo in Japanese");
 
-    let locations = extract_value(&result);
+    let locations = extract_text_as_value(&result);
     let arr = locations.as_array().expect("expected array of locations");
     assert!(!arr.is_empty(), "expected at least one geocode result");
 


### PR DESCRIPTION
Addresses the 2026-06-08 MCP fleet review. Closes #5, #6, #7, #8.

All gates green (cargo test + clippy -D warnings + fmt). See the linked issues for per-finding detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)