### PR TITLE
Purpose-first server instructions + honest reverse_geocode description

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -158,16 +158,83 @@ fn value_as_u64(v: &Value) -> Option<u64> {
     v.as_u64().or_else(|| v.as_str()?.parse::<u64>().ok())
 }
 
+/// Build the MCP server configuration.
+///
+/// The `instructions` blurb is emitted in the `initialize` response and is what
+/// the daemon indexes as this server's model-facing, searchable description, so
+/// it must lead with purpose and name the tools.
+fn server_config() -> ServerConfig {
+    ServerConfig::new("geocode-mcp", env!("CARGO_PKG_VERSION"))
+        .without_websocket()
+        .instructions(
+            "Geocoding tools backed by the Photon API (OpenStreetMap): \
+             resolve place names to coordinates and back.",
+        )
+}
+
 #[tokio::main]
 async fn main() -> mcp_core::Result<()> {
-    mcp_core::run_simple(
-        ServerConfig::new("geocode-mcp", env!("CARGO_PKG_VERSION"))
-            .without_websocket()
-            .instructions(
-                "Geocoding tools backed by the Photon API (OpenStreetMap): \
-                 resolve place names to coordinates and back.",
-            ),
-        || async { Ok(GeocodeService::new()) },
-    )
-    .await
+    mcp_core::run_simple(server_config(), || async { Ok(GeocodeService::new()) }).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Look up a tool's description by name from the live service definition.
+    fn tool_description(name: &str) -> String {
+        GeocodeService::new()
+            .tools()
+            .into_iter()
+            .find(|t| t.name == name)
+            .unwrap_or_else(|| panic!("tool '{name}' not found in tools()"))
+            .description
+    }
+
+    /// The server must advertise a non-empty, model-facing `instructions` blurb —
+    /// the daemon uses it as this server's searchable description.
+    #[test]
+    fn server_config_sets_non_empty_instructions() {
+        let instructions = server_config()
+            .instructions
+            .expect("server_config() must set instructions");
+        assert!(
+            !instructions.trim().is_empty(),
+            "instructions must not be empty or whitespace-only"
+        );
+    }
+
+    /// The instructions must name both tools and the core concepts a model would
+    /// search on, so tool discovery routes location questions here.
+    #[test]
+    fn instructions_name_both_tools_and_core_concepts() {
+        let instructions = server_config()
+            .instructions
+            .expect("server_config() must set instructions")
+            .to_lowercase();
+        for needle in ["geocode", "reverse_geocode", "coordinates", "latitude"] {
+            assert!(
+                instructions.contains(needle),
+                "instructions should mention '{needle}', got: {instructions}"
+            );
+        }
+    }
+
+    /// `reverse_geocode` must describe itself in natural terms (coordinates, a
+    /// GPS point, a place) and must not claim to return a full street address —
+    /// the server only surfaces name, country, region, and place type.
+    #[test]
+    fn reverse_geocode_description_is_natural_and_honest() {
+        let desc = tool_description("reverse_geocode").to_lowercase();
+        for needle in ["coordinates", "latitude", "place", "gps"] {
+            assert!(
+                desc.contains(needle),
+                "reverse_geocode description should mention '{needle}', got: {desc}"
+            );
+        }
+        assert!(
+            !desc.contains("address"),
+            "reverse_geocode must not over-claim returning an 'address': {desc}"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,10 +55,10 @@ impl McpService for GeocodeService {
             ),
             ToolDef::new(
                 "reverse_geocode",
-                "Resolve geographic coordinates (latitude and longitude) to a location name \
-                 and address using the Photon reverse geocoding API (powered by OpenStreetMap). \
-                 Returns the nearest matching location with its name, country, region, and \
-                 place type.",
+                "Resolve geographic coordinates (latitude and longitude) into the nearest place: \
+                 its name, country, country code, region, and place type. Use this to identify \
+                 what is located at a GPS point or to turn a lat/long fix into a human-readable \
+                 place name. Powered by the Photon reverse geocoding API (OpenStreetMap).",
                 json!({
                     "type": "object",
                     "properties": {
@@ -167,8 +167,15 @@ fn server_config() -> ServerConfig {
     ServerConfig::new("geocode-mcp", env!("CARGO_PKG_VERSION"))
         .without_websocket()
         .instructions(
-            "Geocoding tools backed by the Photon API (OpenStreetMap): \
-             resolve place names to coordinates and back.",
+            "Convert between place names and geographic coordinates. Reach for this \
+             whenever you need the latitude and longitude of a city, street address, \
+             landmark, or point of interest (use `geocode`), or need to turn a lat/long \
+             pair back into a human-readable place name, country, and region (use \
+             `reverse_geocode`) -- for example to supply coordinates to a weather, \
+             mapping, or distance lookup, or to identify where a GPS fix is located. \
+             Backed by the Photon API (OpenStreetMap) with global coverage and no API \
+             key or configuration required; every result is structured (coordinates, \
+             country, country code, region, and place type).",
         )
 }
 

--- a/tests/mcp_stdio_suite.rs
+++ b/tests/mcp_stdio_suite.rs
@@ -205,6 +205,39 @@ fn test_initialize_response_shape() {
     );
 }
 
+/// The `initialize` response must carry a non-empty `instructions` string that
+/// names the server's tools — this is exactly the value the daemon indexes as
+/// the server's searchable, model-facing description.
+#[test]
+fn test_initialize_advertises_non_empty_instructions() {
+    let mut client = McpStdioClient::start();
+    let resp = client
+        .call(
+            "initialize",
+            json!({"protocolVersion":"2025-11-25","capabilities":{}}),
+        )
+        .expect("initialize");
+
+    let result = resp.get("result").expect("result field");
+    let instructions = result
+        .get("instructions")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("initialize result must include instructions: {result}"));
+
+    assert!(
+        !instructions.trim().is_empty(),
+        "instructions must not be empty: {result}"
+    );
+
+    let lower = instructions.to_lowercase();
+    for needle in ["geocode", "reverse_geocode", "coordinates"] {
+        assert!(
+            lower.contains(needle),
+            "instructions should mention '{needle}', got: {instructions}"
+        );
+    }
+}
+
 /// `tools/list` must return the expected set of tool names.
 #[test]
 fn test_tools_list_contains_expected_tools() {


### PR DESCRIPTION
## What

Part of the fleet-wide pass to make Adele's tool discovery give the right information at both levels.

**Server level** -- the `.instructions(...)` blurb (emitted in the `initialize` response and indexed by the daemon as this server's searchable description) was thin and mechanism-first: a single sentence, no tool names, no "when to use it". Rewritten to lead with purpose:

> Convert between place names and geographic coordinates. Reach for this whenever you need the latitude and longitude of a city, street address, landmark, or point of interest (use `geocode`), or need to turn a lat/long pair back into a human-readable place name, country, and region (use `reverse_geocode`) -- for example to supply coordinates to a weather, mapping, or distance lookup, or to identify where a GPS fix is located. Backed by the Photon API (OpenStreetMap) with global coverage and no API key or configuration required; every result is structured (coordinates, country, country code, region, and place type).

**Tool level** -- `reverse_geocode` claimed it resolves coordinates "to a location name **and address**", but the server only surfaces name, country, country code, region, and place type (no street address). Reworded to lead with purpose in natural terms and stop over-claiming. `geocode`'s description was already purpose-first and honest and is left unchanged.

## Tests (TDD -- failing tests committed first)

- `server_config_sets_non_empty_instructions` -- the builder sets a non-empty blurb.
- `instructions_name_both_tools_and_core_concepts` -- names `geocode`, `reverse_geocode`, coordinates, latitude.
- `test_initialize_advertises_non_empty_instructions` -- the `initialize` response carries those instructions end-to-end (the exact value the daemon indexes).
- `reverse_geocode_description_is_natural_and_honest` -- natural terms present (coordinates/latitude/place/gps), no "address" over-claim.

## Gate

`just check` green (fmt, clippy `-D warnings`, build, test -- 27 tests). No dependency or lockfile change.

Closes #13